### PR TITLE
refactor(replica.go)

### DIFF
--- a/replica/instance.go
+++ b/replica/instance.go
@@ -1039,3 +1039,11 @@ func (i *Instance) checkStatus(statusList ...uint8) {
 		panic("")
 	}
 }
+
+func (i *Instance) Executed() bool {
+	return i.executed
+}
+
+func (i *Instance) SetExecuted() {
+	i.executed = true
+}

--- a/replica/instance_test.go
+++ b/replica/instance_test.go
@@ -35,6 +35,15 @@ func commonTestlibUnionedDeps() data.Dependencies {
 	return deps
 }
 
+func commonTestlibExampleReplica() *Replica {
+	param := &Param{
+		ReplicaId:    0,
+		Size:         5,
+		StateMachine: new(test.DummySM),
+	}
+	return New(param)
+}
+
 func commonTestlibExampleInstance() *Instance {
 	param := &Param{
 		ReplicaId:    0,
@@ -2998,4 +3007,11 @@ func TestCheckStatus(t *testing.T) {
 
 	assert.Panics(t, func() { i.checkStatus(preAccepted, accepted, preparing) })
 	assert.NotPanics(t, func() { i.checkStatus(committed) })
+}
+
+func TestExecuted(t *testing.T) {
+	i := &Instance{}
+	assert.False(t, i.Executed())
+	i.SetExecuted()
+	assert.True(t, i.Executed())
 }

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -90,7 +90,7 @@ func New(param *Param) (r *Replica) {
 		Id:               replicaId,
 		Size:             size,
 		MaxInstanceNum:   make([]uint64, size),
-		ProposeNum:       1,
+		ProposeNum:       1, // instance.id start from 1
 		CheckpointCycle:  cycle,
 		ExecutedUpTo:     make([]uint64, size),
 		InstanceMatrix:   make([][]*Instance, size),
@@ -337,7 +337,7 @@ func (r *Replica) findAndExecute() {
 			if instance == nil || !instance.isAtStatus(committed) {
 				break
 			}
-			if instance.executed {
+			if instance.Executed() {
 				r.ExecutedUpTo[i]++
 				continue
 			}
@@ -380,14 +380,19 @@ func (r *Replica) resolveConflicts(node *Instance) bool {
 	node.sccLowlink = r.sccIndex
 	r.sccIndex++
 
-	r.sccStack.PushBack(node)
+	r.pushSccStack(node)
 	for iSpace := 0; iSpace < int(r.Size); iSpace++ {
 		dep := node.deps[iSpace]
+		if dep == conflictNotFound || r.IsCheckpoint(dep) {
+			continue
+		}
+
 		neighbor := r.InstanceMatrix[iSpace][dep]
 		if neighbor.status != committed {
 			return false
 		}
-		if neighbor.executed {
+
+		if neighbor.Executed() {
 			continue
 		}
 
@@ -399,8 +404,8 @@ func (r *Replica) resolveConflicts(node *Instance) bool {
 				node.sccLowlink = neighbor.sccLowlink
 			}
 		} else if r.inSccStack(neighbor) {
-			if neighbor.sccLowlink < node.sccLowlink {
-				node.sccLowlink = neighbor.sccLowlink
+			if neighbor.sccIndex < node.sccLowlink {
+				node.sccLowlink = neighbor.sccIndex
 			}
 		}
 	}
@@ -408,7 +413,7 @@ func (r *Replica) resolveConflicts(node *Instance) bool {
 	if node.sccLowlink == node.sccIndex {
 		for {
 			n := r.popSccStack()
-			r.sccResult.PushBack(n)
+			r.pushSccResult(n)
 			if node == n {
 				break
 			}
@@ -416,6 +421,14 @@ func (r *Replica) resolveConflicts(node *Instance) bool {
 	}
 
 	return true
+}
+
+func (r *Replica) pushSccStack(i *Instance) {
+	r.sccStack.PushBack(i)
+}
+
+func (r *Replica) pushSccResult(i *Instance) {
+	r.sccResult.PushBack(i)
 }
 
 func (r *Replica) inSccStack(other *Instance) bool {

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -95,3 +95,280 @@ func TestUpdateInstance(t *testing.T) {
 	assert.True(t, changed)
 	assert.Equal(t, i.deps, expectedDeps)
 }
+
+// This func tests the correctness of inSccStack() pushSccStack() and  popSccStack()
+func TestSccStack(t *testing.T) {
+	i := commonTestlibExampleCommittedInstance()
+	iClone := commonTestlibCloneInstance(i)
+	iClone.ballot = iClone.ballot.IncNumClone()
+	r := i.replica
+
+	// push two items
+	r.pushSccStack(i)
+	r.pushSccStack(iClone)
+
+	// test if they are valid in the stack
+	assert.True(t, r.inSccStack(i))
+	assert.True(t, r.inSccStack(iClone))
+
+	// pop out one item and test if it's valid
+	iPop := r.popSccStack()
+	assert.Equal(t, iClone, iPop)
+	assert.NotEqual(t, i, iPop)
+
+	// test the content in the stack
+	assert.False(t, r.inSccStack(iClone))
+	assert.True(t, r.inSccStack(i))
+
+	// pop out another one and test if it's valid
+	iPop = r.popSccStack()
+	assert.Equal(t, i, iPop)
+	assert.NotEqual(t, iClone, iPop)
+
+	// test the content of the stack
+	assert.False(t, r.inSccStack(i))
+}
+
+// Testings to test the correctness of resolveConflicts()
+
+// **********************
+// ***** 1, no deps *****
+// **********************
+func TestResolveConflictsWithNoDeps(t *testing.T) {
+	r := commonTestlibExampleReplica()
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][1] = NewInstance(r, uint8(i), 1)
+	}
+
+	assert.True(t, r.resolveConflicts(r.InstanceMatrix[0][1]))
+	assert.Equal(t, r.sccResult.Len(), 1)
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][1])
+}
+
+// **************************************
+// ***** 2, one level depth of deps *****
+// **************************************
+func TestResolveConflictsWithSimpleDeps(t *testing.T) {
+	r := commonTestlibExampleReplica()
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][i+2] = NewInstance(r, uint8(i), uint64(i+2))
+		r.InstanceMatrix[i][i+2].status = committed
+	}
+	r.InstanceMatrix[0][3] = NewInstance(r, 0, 3)
+	r.InstanceMatrix[0][3].deps = data.Dependencies{2, 3, 4, 5, 6}
+	assert.True(t, r.resolveConflicts(r.InstanceMatrix[0][3]))
+	assert.Equal(t, r.sccResult.Len(), 6)
+
+	for i := range r.InstanceMatrix {
+		assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[i][i+2])
+	}
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][3])
+}
+
+// ***************************************************************
+// ***** 3, mutiple levels of depth of deps, (acyclic graph) *****
+// ***************************************************************
+
+// InstanceMatrix:
+//
+//   2 <---|         |---4 <------ 6
+//   3 <---|         |---5 <-----/
+//   4 <---| mapping |---6 <----/
+//   5 <---|         |---7 <---/
+//   6 <---|         |---8 <--/
+//
+func TestResolveConflictsWithMultipleLevelDeps(t *testing.T) {
+	r := commonTestlibExampleReplica()
+	r.InstanceMatrix[0][6] = NewInstance(r, 0, 6)
+	r.InstanceMatrix[0][6].status = committed
+	r.InstanceMatrix[0][6].deps = data.Dependencies{4, 5, 6, 7, 8}
+
+	// create 1st level deps (4, 5, 6, 7, 8)
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][i+4] = NewInstance(r, uint8(i), uint64(i+4))
+		r.InstanceMatrix[i][i+4].status = committed
+	}
+	r.InstanceMatrix[0][4].deps = data.Dependencies{2, 0, 0, 0, 0}
+	r.InstanceMatrix[1][5].deps = data.Dependencies{2, 3, 0, 0, 0}
+	r.InstanceMatrix[2][6].deps = data.Dependencies{2, 3, 4, 0, 0}
+	r.InstanceMatrix[3][7].deps = data.Dependencies{2, 3, 4, 5, 0}
+	r.InstanceMatrix[4][8].deps = data.Dependencies{2, 3, 4, 5, 6}
+
+	// create 2nd level deps (2, 3, 4, 5, 6)
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][i+2] = NewInstance(r, uint8(i), uint64(i+2))
+		r.InstanceMatrix[i][i+2].status = committed
+	}
+
+	assert.True(t, r.resolveConflicts(r.InstanceMatrix[0][6]))
+	assert.Equal(t, r.sccResult.Len(), 11)
+
+	// test result list
+	for i := range r.InstanceMatrix {
+		assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[i][i+2])
+		assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[i][i+4])
+	}
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][6])
+}
+
+// ******************************************************************
+// ***** 4, multiple levels of depth of deps, (contains cycles) *****
+// ******************************************************************
+
+// InstanceMatrix:
+//
+//   --------------------------
+//  |  |                       |
+//  |  |                       |
+//  |  2 <---|         |---4 <-|------- 6
+//   --3 <---|         |---5 <-/-------/
+//     4 <---| mapping |---6 <--------/
+//     5 <---|         |---7 <-------/
+//     6 <---|         |---8 <------/
+//
+func TestResolveConflictsWithSccDeps(t *testing.T) {
+	r := commonTestlibExampleReplica()
+	r.InstanceMatrix[0][6] = NewInstance(r, 0, 6)
+	r.InstanceMatrix[0][6].status = committed
+	r.InstanceMatrix[0][6].deps = data.Dependencies{4, 5, 6, 7, 8}
+
+	// create 1st level deps (4, 5, 6, 7, 8)
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][i+4] = NewInstance(r, uint8(i), uint64(i+4))
+		r.InstanceMatrix[i][i+4].status = committed
+	}
+	r.InstanceMatrix[0][4].deps = data.Dependencies{2, 0, 0, 0, 0}
+	r.InstanceMatrix[1][5].deps = data.Dependencies{0, 3, 0, 0, 0}
+	r.InstanceMatrix[2][6].deps = data.Dependencies{0, 0, 4, 0, 0}
+	r.InstanceMatrix[3][7].deps = data.Dependencies{0, 0, 0, 5, 0}
+	r.InstanceMatrix[4][8].deps = data.Dependencies{0, 0, 0, 0, 6}
+
+	// create 2nd level deps (2, 3, 4, 5, 6)
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][i+2] = NewInstance(r, uint8(i), uint64(i+2))
+		r.InstanceMatrix[i][i+2].status = committed
+	}
+
+	// create a scc (2->4, 2->5, 3->4, 3->5)
+	r.InstanceMatrix[0][2].deps = data.Dependencies{4, 5, 0, 0, 0}
+	r.InstanceMatrix[1][3].deps = data.Dependencies{4, 5, 0, 0, 0}
+
+	assert.True(t, r.resolveConflicts(r.InstanceMatrix[0][6]))
+	assert.Equal(t, r.sccResult.Len(), 11)
+
+	// test result list
+	// scc components
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[1][3])
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[1][5])
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][2])
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][4])
+
+	// other nodes
+	for i := 2; i < int(r.Size); i++ {
+		assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[i][i+2])
+		assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[i][i+4])
+	}
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][6])
+}
+
+// ***************************************************************************************
+// ***** 5, same multiple levels of depth of deps, but with an un-committed instance *****
+// ***************************************************************************************
+func TestResolveConflictsWithSccDepsAndUncommitedInstance(t *testing.T) {
+	r := commonTestlibExampleReplica()
+	r.InstanceMatrix[0][6] = NewInstance(r, 0, 6)
+	r.InstanceMatrix[0][6].status = committed
+	r.InstanceMatrix[0][6].deps = data.Dependencies{4, 5, 6, 7, 8}
+
+	// create 1st level deps (4, 5, 6, 7, 8)
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][i+4] = NewInstance(r, uint8(i), uint64(i+4))
+		r.InstanceMatrix[i][i+4].status = committed
+	}
+	r.InstanceMatrix[0][4].deps = data.Dependencies{2, 0, 0, 0, 0}
+	r.InstanceMatrix[1][5].deps = data.Dependencies{0, 3, 0, 0, 0}
+	r.InstanceMatrix[2][6].deps = data.Dependencies{0, 0, 4, 0, 0}
+	r.InstanceMatrix[3][7].deps = data.Dependencies{0, 0, 0, 5, 0}
+	r.InstanceMatrix[4][8].deps = data.Dependencies{0, 0, 0, 0, 6}
+
+	// create 2nd level deps (2, 3, 4, 5, 6)
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][i+2] = NewInstance(r, uint8(i), uint64(i+2))
+		r.InstanceMatrix[i][i+2].status = committed
+	}
+
+	// create a scc (2->4, 2->5, 3->4, 3->5)
+	r.InstanceMatrix[0][2].deps = data.Dependencies{4, 5, 0, 0, 0}
+	r.InstanceMatrix[1][3].deps = data.Dependencies{4, 5, 0, 0, 0}
+
+	// create an un-committed instance
+	r.InstanceMatrix[4][6].status = accepted
+
+	assert.False(t, r.resolveConflicts(r.InstanceMatrix[0][6]))
+	assert.Equal(t, r.sccResult.Len(), 8)
+
+	// test result list
+	// scc components
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[1][3])
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[1][5])
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][2])
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][4])
+
+	// other nodes
+	for i := 2; i < int(r.Size)-1; i++ {
+		assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[i][i+2])
+		assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[i][i+4])
+	}
+}
+
+// ************************************************************************************
+// ***** 6, same multiple levels of depth of deps, but with an executed instance ******
+// ************************************************************************************
+func TestResolveConflictsWithSccDepsAndexecutedInstance(t *testing.T) {
+	r := commonTestlibExampleReplica()
+	r.InstanceMatrix[0][6] = NewInstance(r, 0, 6)
+	r.InstanceMatrix[0][6].status = committed
+	r.InstanceMatrix[0][6].deps = data.Dependencies{4, 5, 6, 7, 8}
+
+	// create 1st level deps (4, 5, 6, 7, 8)
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][i+4] = NewInstance(r, uint8(i), uint64(i+4))
+		r.InstanceMatrix[i][i+4].status = committed
+	}
+	r.InstanceMatrix[0][4].deps = data.Dependencies{2, 0, 0, 0, 0}
+	r.InstanceMatrix[1][5].deps = data.Dependencies{0, 3, 0, 0, 0}
+	r.InstanceMatrix[2][6].deps = data.Dependencies{0, 0, 4, 0, 0}
+	r.InstanceMatrix[3][7].deps = data.Dependencies{0, 0, 0, 5, 0}
+	r.InstanceMatrix[4][8].deps = data.Dependencies{0, 0, 0, 0, 6}
+
+	// create 2nd level deps (2, 3, 4, 5, 6)
+	for i := range r.InstanceMatrix {
+		r.InstanceMatrix[i][i+2] = NewInstance(r, uint8(i), uint64(i+2))
+		r.InstanceMatrix[i][i+2].status = committed
+	}
+
+	// create a scc (2->4, 2->5, 3->4, 3->5)
+	r.InstanceMatrix[0][2].deps = data.Dependencies{4, 5, 0, 0, 0}
+	r.InstanceMatrix[1][3].deps = data.Dependencies{4, 5, 0, 0, 0}
+
+	// create an executed instance
+	// [*] Note: The deps of [4][8] won't be executed either.
+	r.InstanceMatrix[4][8].SetExecuted()
+
+	assert.True(t, r.resolveConflicts(r.InstanceMatrix[0][6]))
+	assert.Equal(t, r.sccResult.Len(), 9)
+
+	// test result list
+	// scc components
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[1][3])
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[1][5])
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][2])
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][4])
+
+	// other nodes
+	for i := 2; i < int(r.Size)-1; i++ {
+		assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[i][i+2])
+		assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[i][i+4])
+	}
+	assert.Equal(t, r.sccResult.Remove(r.sccResult.Front()), r.InstanceMatrix[0][6])
+}


### PR DESCRIPTION
Change list.New() to list.Init() to reduce memory operations.
Modify the 'equal' condition since they are both pointers, we can compare them directly.

fmt(instance.go)
